### PR TITLE
 first-13-things-linux/README.md - Adding verification step to 'reconfigure unattended-upgrades'

### DIFF
--- a/first-13-things-linux/README.md
+++ b/first-13-things-linux/README.md
@@ -15,9 +15,13 @@ sudo apt-get update
 sudo apt-get upgrade
 ```
 
-Reconfigure
+Reconfigure unattended-upgrades
 
 `sudo dpkg-reconfigure --priority=low unattended-upgrades`
+
+Verify Reconfiguration file in your text editor of choice
+
+`/etc/apt/apt.conf.d/20auto-upgrades`
 
 
 ## Account

--- a/first-13-things-linux/README.md
+++ b/first-13-things-linux/README.md
@@ -19,7 +19,7 @@ Reconfigure unattended-upgrades
 
 `sudo dpkg-reconfigure --priority=low unattended-upgrades`
 
-Verify Reconfiguration file in your text editor of choice
+Verify unattended upgrades configuration file in your text editor of choice
 
 `/etc/apt/apt.conf.d/20auto-upgrades`
 


### PR DESCRIPTION
Added a sub-step for the verification of reconfigure unattended-upgrades step.

Adding this step due to opportunity for confusion in the video at the 2:41 mark where TT indicated to select 'no' followed by indicating to select 'y' on the same step. It was probably intended that the 'no' direction be edited out, however, it remained in the video...  I felt it important to verify the configuration and had to look up the file location.