### PR TITLE
portainer-2-kubernetes/README.md - Adding example Portainer URL

### DIFF
--- a/portainer-2-kubernetes/README.md
+++ b/portainer-2-kubernetes/README.md
@@ -120,5 +120,6 @@ kubectl apply -n portainer -f https://raw.githubusercontent.com/portainer/k8s/ma
 ```
 
 The Portainer UI is hosted on port `30777`
- Example: `http://192.168.0.1:30777`
+
+      Example: `http://192.168.0.1:30777`
 

--- a/portainer-2-kubernetes/README.md
+++ b/portainer-2-kubernetes/README.md
@@ -120,4 +120,5 @@ kubectl apply -n portainer -f https://raw.githubusercontent.com/portainer/k8s/ma
 ```
 
 The Portainer UI is hosted on port `30777`
+ Example: `http://192.168.0.1:30777`
 


### PR DESCRIPTION
Added an example Portainer URL to reduce possible confusion/frustration.