### PR TITLE
Removed unnecessary rm step

### DIFF
--- a/first-11-things-proxmox/README.md
+++ b/first-11-things-proxmox/README.md
@@ -141,7 +141,6 @@ change hosts file
 reset machine ID
 
 ```
-sudo rm /etc/machine-id
 sudo rm /var/lib/dbus/machine-id
 sudo truncate -s 0 /etc/machine-id
 sudo ln -s /etc/machine-id /var/lib/dbus/machine-id


### PR DESCRIPTION
If you remove this `rm` step I believe the results will be the same, except you will preserve any ownership and permissions of the file to be truncated.

Not sure how the last line of the file got caught up in my pull request. I'm sorry about that.