### PR TITLE
Updated MetalLB install Matafet URL's to v0.9.5.

### DIFF
--- a/reverse-proxy-kubernetes/README.md
+++ b/reverse-proxy-kubernetes/README.md
@@ -20,9 +20,9 @@ https://kubernetes.io/docs/tasks/tools/install-kubectl/
 
 https://metallb.universe.tf/installation/
 
-`kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml`
 
-`kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml`
 
 You should only ever run this step once.
 


### PR DESCRIPTION
When following you video with Rancher version 2.5.1 MetalLB version 0.9.3 would not work for me at all. Upgraded MetalLB to version 0.9.5 and it start working and have reconfirm this on another host.