### PR TITLE
Rancher k8s updates

### DIFF
--- a/k3s-ha-install/README.md
+++ b/k3s-ha-install/README.md
@@ -38,11 +38,6 @@ On your k3s servers
 
 `export K3S_DATASTORE_ENDPOINT='mysql://username:password@tcp(database_ip_or_hostname:port)/database'`
 
-If you plan on installing rancher in this cluser, the current stabe release (v2.5.5) does not support K3S v1.20. To prevent
-issues when installing rancher, be sure to include the following:
-
-`export INSTALL_K3S_VERSION=v1.19.7+k3s1`
-
 then 
 
 ```
@@ -86,7 +81,7 @@ To install `kubectl` [see this link](https://kubernetes.io/docs/tasks/tools/inst
 
 copy contents to your dev machine
 
-`~/.kube/config`
+`~/kube/config`
 
 
 Be sure to update the `server:` to your load balancer ip or hostname

--- a/rancher-install-k8s/README.md
+++ b/rancher-install-k8s/README.md
@@ -14,6 +14,11 @@ https://www.youtube.com/watch?v=APsZJbnluXg
 
 ## install
 
+**Note:** The current stable release of rancher, [rancher v2.5.5](https://github.com/rancher/rancher/releases/tag/v2.5.5),
+is restricted to Kubernetes version less than 1.20.0. Please see the 
+[Rancher support matrix](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.5.5/) 
+for more details on which version of K3S/K8s to use.
+
 https://rancher.com/docs/rancher/v2.x/en/installation/install-rancher-on-k8s/#1-install-the-required-cli-tools
 
 `kubectl`
@@ -47,7 +52,7 @@ install `cert-manager`
 
 
 ```
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
 ```
 
 create name-space for `cert-manager`
@@ -74,11 +79,13 @@ helm repo update
 install `cert-manager` helm chart
 
 
+*Note: If you receive an "Error: Kubernetes cluster unreachable" message when install cert-manager, try copying
+the contents of "/etc/rancher/k3s/k3s.yam" to "~/.kube/config" to resolve the issue.*
 ```
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.0.4
+  --version v1.1.0
 ```
 
 check rollout of cert-manager

--- a/rancher-install-k8s/README.md
+++ b/rancher-install-k8s/README.md
@@ -14,10 +14,9 @@ https://www.youtube.com/watch?v=APsZJbnluXg
 
 ## install
 
-**Note:** The current stable release of rancher, [rancher v2.5.5](https://github.com/rancher/rancher/releases/tag/v2.5.5),
-is restricted to Kubernetes version less than 1.20.0. Please see the 
-[Rancher support matrix](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.5.5/) 
-for more details on which version of K3S/K8s to use.
+**Note:** If you plan on installing rancher in your cluser, the current stabe release (v2.5.5) does not support Kubernetes v1.20.
+It's advised you consult the [Rancher Support Matrix](https://rancher.com/support-maintenance-terms/all-supported-versions)
+to get the recommended version for all Rancher dependencies.
 
 https://rancher.com/docs/rancher/v2.x/en/installation/install-rancher-on-k8s/#1-install-the-required-cli-tools
 


### PR DESCRIPTION
* Added a quick disclaimer for those using newer version of k8s/k3s.
* Bumped up the release of cert-manager to `1.1.0` from `1.0.4`.
* Added a quick troubleshooting step for `helm install`.